### PR TITLE
fix: multiple pod Labels/Annotations fail rendering

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying pgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 2.1.1
+version: 2.1.2
 appVersion: 1.20.1
 kubeVersion: ">= 1.20.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         {{- include "pgbouncer.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}
-        {{ range $key, $value := .Values.podLabels -}}
+        {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end -}}
         {{- end }}
@@ -32,7 +32,7 @@ spec:
         prometheus.io/port: "{{ .Values.pgbouncerExporter.port }}"
         prometheus.io/path: "/metrics"
         {{- end }}
-        {{ range $key, $value := .Values.podAnnotations -}}
+        {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:


### PR DESCRIPTION
When defining multiple pod labels or annotations - helm rendering fails with:

`Error: YAML parse error on pgbouncer/charts/pgbouncer/templates/deployment.yaml: error converting YAML to JSON: yaml: line 23: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 23: did not find expected key
`

This PR should fix it.