### PR TITLE
issue#4 accept custom secrets to gpt retrieval web deployment

### DIFF
--- a/charts/chatgpt-retrieval-plugin/Chart.yaml
+++ b/charts/chatgpt-retrieval-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chatgpt-retrieval-plugin
 description: ChatGPT Retrieval Plugin Helm chart for Kubernetes
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: "0.0.1"
 keywords:
   - docker

--- a/charts/chatgpt-retrieval-plugin/templates/web-deployment.yaml
+++ b/charts/chatgpt-retrieval-plugin/templates/web-deployment.yaml
@@ -39,6 +39,10 @@ spec:
               name: {{ template "app.web-env.name" . }}
           - secretRef:
               name: {{ template "app.web-env.name" . }}
+        {{- range .Values.web.extraEnvFromSecret }}
+          - secretRef:
+              name: {{ tpl . $ }}
+        {{- end }}
         ports:
           - name: http
             containerPort: {{ .Values.web.service.port }}

--- a/charts/chatgpt-retrieval-plugin/values.yaml
+++ b/charts/chatgpt-retrieval-plugin/values.yaml
@@ -96,3 +96,6 @@ web:
   #     value: "xxxxx"
   #   - name: OPENAI_API_KEY
   #     value: "xxxxx"
+  extraEnvFromSecret: []
+  # extraEnvFromSecret:
+  #   - custom-secret    


### PR DESCRIPTION
The suggested code change resolves https://github.com/icoretech/helm/issues/4 
Users are able to configure additional secrets to be consumed by the chatgpt-retrieval-plugin web deployment