### PR TITLE
PodMonitor Resource

### DIFF
--- a/charts/pgbouncer/templates/podmonitor.yaml
+++ b/charts/pgbouncer/templates/podmonitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.pgbouncerExporter.podMonitor -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "pgbouncer.fullname" . }}
+  labels:
+    {{- include "pgbouncer.selectorLabels" . | nindent 8 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "pgbouncer.selectorLabels" . | nindent 8 }}
+  podMetricsEndpoints:
+    - port: exporter
+  {{- end }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -190,6 +190,7 @@ extraVolumes: []
 ##
 pgbouncerExporter:
   enabled: false
+  podMonitor: true
   port: 9127
   image:
     registry: ""


### PR DESCRIPTION
Hi, 

I wanted to be able to monitor via kube-prometheus-stack. For that I added a PodMonitor. This way prometheus is picking up the exporter metrics without further configuration.