### PR TITLE
Add support to customize entrypoint for pgbouncer container

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying pgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 2.3.3
+version: 2.3.4
 appVersion: 1.23.1
 kubeVersion: ">= 1.20.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png

--- a/charts/pgbouncer/README.md
+++ b/charts/pgbouncer/README.md
@@ -38,6 +38,8 @@ The following table lists the configurable parameters of the pgBouncer chart and
 | `image.repository`              | Image repository for pgBouncer.                                                                                                       | `ghcr.io/icoretech/pgbouncer-docker` |
 | `image.tag`                     | Specific image tag to use.                                                                                                            | `1.23.1-fixed`                       |
 | `image.pullPolicy`              | Image pull policy. Options: `Always`, `Never`, `IfNotPresent`.                                                                        | `IfNotPresent`                       |
+| `command`                       | Custom entrypoint command for pgbouncer container                                                                                     | `[]`                       |
+| `args`                          | Custom entrypoint args for pgbouncer container                                                                                        | `[]`                       |
 | `service.type`                  | Kubernetes Service type (e.g., `ClusterIP`, `NodePort`).                                                                              | `ClusterIP`                          |
 | `service.port`                  | Port for the pgBouncer service.                                                                                                       | `5432`                               |
 | `podLabels`                     | Custom labels for pods. Format: `key: value`.                                                                                         | `{}`                                 |

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -62,6 +62,14 @@ spec:
       containers:
       - name: pgbouncer
         image: {{ template "pgbouncer.image" . }}
+        {{- if .Values.command }}
+        command:
+        {{ .Values.command | toYaml | indent 10 }}
+        {{- end }}
+        {{- if .Values.args }}
+        args:
+        {{ .Values.args | toYaml | indent 10 }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.lifecycle }}
         lifecycle: {{ toYaml .Values.lifecycle | trimSuffix "\n" | nindent 10 }}

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -64,11 +64,11 @@ spec:
         image: {{ template "pgbouncer.image" . }}
         {{- if .Values.command }}
         command:
-        {{ .Values.command | toYaml | indent 10 }}
+        {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         {{- if .Values.args }}
         args:
-        {{ .Values.args | toYaml | indent 10 }}
+        {{ toYaml .Values.args | nindent 10 }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.lifecycle }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -39,6 +39,13 @@ image:
   tag: 1.23.1-fixed
   pullPolicy: IfNotPresent
 
+# If a custom entrypoint is needed/desired to configure pgbouncer container it can be configured with a combination of command and args lists
+# command:
+#   - "/bin/myapp"
+# args:
+#   - "--config"
+#   - "/etc/config.yaml"
+
 ## Service configuration
 ## https://kubernetes.io/docs/concepts/services-networking/service/
 ##


### PR DESCRIPTION
This change makes the chart support using different pgbouncer images that don't already have an entrypoint set that works with how the chart creates and mounts the pgbouncer config. 