### PR TITLE
support ReadOnlyRootFilesystem

### DIFF
--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -95,7 +95,12 @@ spec:
         {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | trimSuffix "\n" | nindent 10 }}
         {{- end }}
+        {{- if .Values.securityContext }}
+        securityContext: {{ toYaml .Values.securityContext | trimSuffix "\n" | nindent 10 }}
+        {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: config
           mountPath: /etc/pgbouncer/
         - name: userlist
@@ -127,6 +132,9 @@ spec:
         {{- if .Values.pgbouncerExporter.resources }}
         resources: {{ toYaml .Values.pgbouncerExporter.resources | trimSuffix "\n" | nindent 10 }}
         {{- end }}
+        {{- if .Values.securityContext }}
+        securityContext: {{ toYaml .Values.pgbouncerExporter.securityContext | trimSuffix "\n" | nindent 10 }}
+        {{- end }}
         ports:
         - name: exporter
           containerPort: {{ .Values.pgbouncerExporter.port }}
@@ -136,6 +144,8 @@ spec:
       {{ toYaml .Values.extraContainers | trimSuffix "\n" | indent 6 | trimPrefix "      " }}
       {{ end -}}
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: config
         configMap:
           name: {{ template "pgbouncer.fullname" . }}-configmap

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -175,6 +175,16 @@ config:
   userlist: {}
     # someUser: secretPassword
 
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 70
+  runAsGroup: 70
+
 # -- Extra containers to run within the PgBouncer pod.
 extraContainers: []
 # - name: some-container
@@ -231,6 +241,15 @@ pgbouncerExporter:
     requests:
       cpu: 30m
       memory: 40Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
 
 # -- Pod Disruption Budget configuration.
 podDisruptionBudget:


### PR DESCRIPTION
To support clusters require a ReadOnlyRootFilesystem for all containers (https://kyverno.io/policies/best-practices/require-ro-rootfs/require-ro-rootfs/)

* add securityContext to containers
* set securityContext.readOnlyRootFilesystem=true

If this MR is acceptable, I'll also update the README.md with the new parameters.
