### PR TITLE
fix: use servicePort instead of port for pgbouncer exporter container

### DIFF
--- a/charts/pgbouncer/templates/daemonset.yaml
+++ b/charts/pgbouncer/templates/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.pgbouncerExporter.enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.pgbouncerExporter.port }}"
+        prometheus.io/port: "{{ .Values.pgbouncerExporter.servicePort }}"
         prometheus.io/path: "/metrics"
         {{- end }}
         {{- range $key, $value := .Values.podAnnotations }}
@@ -110,7 +110,7 @@ spec:
         image: {{ template "pgbouncer.exporterImage" . }}
         imagePullPolicy: {{ .Values.pgbouncerExporter.image.pullPolicy }}
         args:
-        - --web.listen-address=:{{ .Values.pgbouncerExporter.port }}
+        - --web.listen-address=:{{ .Values.pgbouncerExporter.servicePort }}
         - --web.telemetry-path=/metrics
         - --log.level={{ .Values.pgbouncerExporter.log.level }}
         - --log.format={{ .Values.pgbouncerExporter.log.format }}
@@ -134,7 +134,7 @@ spec:
         {{- end }}
         ports:
         - name: exporter
-          containerPort: {{ .Values.pgbouncerExporter.port }}
+          containerPort: {{ .Values.pgbouncerExporter.servicePort }}
           protocol: TCP
       {{- end }}
       {{ if .Values.extraContainers -}}

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
         {{- end }}
         ports:
         - name: exporter
-          containerPort: {{ .Values.pgbouncerExporter.port }}
+          containerPort: {{ .Values.pgbouncerExporter.servicePort }}
           protocol: TCP
       {{- end }}
       {{ if .Values.extraContainers -}}


### PR DESCRIPTION
   ## Description
   Fixes the pgbouncer exporter container port configuration that was broken in the upgrade from v2.8.1 to v3.0.0.

   ## Problem
   The exporter container was incorrectly listening on port 5432 (database port) instead of 9127 (exporter servicePort), causing Prometheus scraping to fail.

   ## Changes
   - Fixed `containerPort` in both deployment.yaml and daemonset.yaml to use `servicePort` (9127) instead of `port` (5432)
   - Fixed `--web.listen-address` argument in daemonset.yaml to use `servicePort`
   - Fixed `prometheus.io/port` annotation in daemonset.yaml to use `servicePort`

   ## Testing
   After this fix:
   - pgbouncer-exporter container will listen on the correct port (9127)
   - Prometheus scraping will work correctly
   - PodMonitor will scrape metrics from the right port

   Fixes #26