### PR TITLE
feat(pgbouncer): add support for [users] section in configuration

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying PgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 3.0.1
+version: 3.1.0
 appVersion: 1.24.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png

--- a/charts/pgbouncer/templates/configmap.yaml
+++ b/charts/pgbouncer/templates/configmap.yaml
@@ -10,6 +10,10 @@ data:
 {{- range $key, $val := .Values.config.databases }}
     {{ $key }} ={{ range $k, $v := $val }} {{ $k }}={{ $v }}{{ end }}
 {{- end }}
+    [users]
+{{- range $key, $val := .Values.config.users }}
+    {{ $key }} ={{ range $k, $v := $val }} {{ $k }}={{ $v }}{{ end }}
+{{- end }}
     [pgbouncer]
     listen_addr = *
     listen_port = 5432

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -165,8 +165,11 @@ config:
   # -- Password for the authUser above, if used.
   authPassword:
 
-  # -- Mapping of database names to connection parameters. E.g.: mydb: host=postgresql port=5432
+  # -- Mapping of database names to connection parameters. E.g.: mydb = host=postgresql port=5432
   databases: {}
+
+  # -- Mapping of usernames to connection parameters. E.g.: someUser = pool_mode=session
+  users: {}
 
   # -- Additional PgBouncer parameters (e.g. auth_type, pool_mode).
   pgbouncer: {}


### PR DESCRIPTION
This PR adds support to customize the `[users]` section in the `pgbouncer.ini`, similarly to the `[databases]` that already can be configured.

This will allow us to configure the `pool_size` per user instead of per database, for example.