### PR TITLE
feat(pgbouncer): Add ability to share process namespace for the pgbouncer pod

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying PgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 3.1.2
+version: 3.1.3
 appVersion: 1.24.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png

--- a/charts/pgbouncer/templates/daemonset.yaml
+++ b/charts/pgbouncer/templates/daemonset.yaml
@@ -55,6 +55,9 @@ spec:
       {{ if len .Values.imagePullSecrets -}}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | trimSuffix "\n" | nindent 6 }}
       {{ end -}}
+      {{ if .Values.shareProcessNamespace -}}
+      shareProcessNamespace: true
+      {{ end -}}
       {{ if .Values.extraInitContainers -}}
       initContainers: {{ toYaml .Values.extraInitContainers | trimSuffix "\n" | nindent 6 }}
       {{ end -}}

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
       imagePullSecrets: {{- toYaml $uniquePullSecrets | nindent 8 }}
       {{- end }}
 
+      {{ if .Values.shareProcessNamespace -}}
+      shareProcessNamespace: true
+      {{ end -}}
+
       {{ if .Values.extraInitContainers -}}
       initContainers: {{ toYaml .Values.extraInitContainers | trimSuffix "\n" | nindent 6 }}
       {{ end -}}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -187,6 +187,9 @@ config:
   userlist: {}
     # someUser: secretPassword
 
+# -- Allow containers in the pod to share the same process namespace.
+shareProcessNamespace: false
+
 # -- Pod security context for the main PgBouncer container. By default, this forces the container to run without root privileges and with a read-only root filesystem.
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
pgbouncer can reload configuration via SIGHUP. If we permit sharing process namespace and utilize an inotifywait script to execute a kill (or pkill) with -HUP against the pgbouncer process from the sidecar container, we can implement config reload without a rolling restart.