### PR TITLE
airbroke: support pod annotations/labels

### DIFF
--- a/charts/airbroke/Chart.yaml
+++ b/charts/airbroke/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbroke
 description: Airbroke Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.1.81"
 keywords:
   - open

--- a/charts/airbroke/Readme.md
+++ b/charts/airbroke/Readme.md
@@ -93,6 +93,8 @@ The following table lists the configurable parameters of the Airbroke chart and 
 | web.livenessProbe.successThreshold | int | `1` |  |
 | web.livenessProbe.timeoutSeconds | int | `5` |  |
 | web.nodeSelector | object | `{}` |  |
+| web.podAnnotations | object | `{}` |  |
+| web.podLabels | object | `{}` |  |
 | web.prismaVersion | string | `"7"` |  |
 | web.readinessProbe.enabled | bool | `true` |  |
 | web.readinessProbe.failureThreshold | int | `2` |  |

--- a/charts/airbroke/templates/web-deployment.yaml
+++ b/charts/airbroke/templates/web-deployment.yaml
@@ -21,9 +21,15 @@ spec:
     metadata:
       labels:
         {{- include "app.web.selectorLabels" . | nindent 8 }}
+        {{- with .Values.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/env-cm: {{ include (print $.Template.BasePath "/web-env-cm.yaml") . | sha256sum }}
         checksum/env-secret: {{ include (print $.Template.BasePath "/web-env-secret.yaml") . | sha256sum }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.web.runtimeClassName }}
       runtimeClassName: {{ .Values.web.runtimeClassName }}

--- a/charts/airbroke/values.yaml
+++ b/charts/airbroke/values.yaml
@@ -14,6 +14,10 @@ web:
   terminationGracePeriodSeconds: 0
   replicaCount: 1
   runtimeClassName:
+  # podAnnotations -- Additional annotations to add to the web Pod template (e.g., `secret.reloader.stakater.com/auto: "true"`).
+  podAnnotations: {}
+  # podLabels -- Additional labels to add to the web Pod template.
+  podLabels: {}
 
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Adds `web.podAnnotations` and `web.podLabels` and wires them into the Deployment pod template.\n\nThis enables patterns like Stakater Reloader (`secret.reloader.stakater.com/auto: "true"`) without post-render patches.\n\nValidation:\n- `helm lint charts/airbroke --set database.url=... --set database.migrations_url=...`\n- `helm template` + `kubeconform -strict -ignore-missing-schemas`\n- Ran `helm-docs` from `charts/airbroke/`