### PR TITLE
feat(nextjs): support configmap env + secret env maps (back-compat)

### DIFF
--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: nextjs
 description: Generic Helm chart for Nextjs apps on Kubernetes
 type: application
-version: 1.1.13
+version: 1.1.14
 appVersion: '1.0.0'
 icon: https://icoretech.github.io/helm/charts/nextjs/logo.png
 keywords:
   - nextjs
 maintainers:
-  - name: Claudio Poli
+  - name: masterkain
     email: claudio@icorete.ch
     url: https://github.com/masterkain
 home: https://github.com/icoretech/helm

--- a/charts/nextjs/Readme.md
+++ b/charts/nextjs/Readme.md
@@ -1,6 +1,6 @@
 # nextjs
 
-![Version: 1.1.13](https://img.shields.io/badge/Version-1.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.14](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for Nextjs apps on Kubernetes
 
@@ -10,7 +10,7 @@ Generic Helm chart for Nextjs apps on Kubernetes
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| Claudio Poli | <claudio@icorete.ch> | <https://github.com/masterkain> |
+| masterkain | <claudio@icorete.ch> | <https://github.com/masterkain> |
 
 ## Source Code
 
@@ -39,6 +39,7 @@ Generic Helm chart for Nextjs apps on Kubernetes
 | web.dataVolume.size | string | `"1Gi"` |  |
 | web.dataVolume.storageClass | string | `""` |  |
 | web.dataVolume.volumeMode | string | `""` |  |
+| web.env | object | `{}` |  |
 | web.extraContainers | list | `[]` |  |
 | web.extraEnvFrom | list | `[]` |  |
 | web.extraEnvs | list | `[]` |  |
@@ -81,6 +82,7 @@ Generic Helm chart for Nextjs apps on Kubernetes
 | web.replicaCount | int | `1` |  |
 | web.resources | object | `{}` |  |
 | web.runtimeClassName | string | `nil` |  |
+| web.secretEnv | object | `{}` |  |
 | web.service.annotations | object | `{}` |  |
 | web.service.enabled | bool | `true` |  |
 | web.service.nodePort | string | `nil` |  |

--- a/charts/nextjs/templates/web-env-cm.yaml
+++ b/charts/nextjs/templates/web-env-cm.yaml
@@ -5,5 +5,12 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 data:
-  AWS_SDK_CONFIG_OPT_OUT: "true"
-  NEXT_TELEMETRY_DISABLED: "1"
+  {{- $defaults := dict "AWS_SDK_CONFIG_OPT_OUT" "true" "NEXT_TELEMETRY_DISABLED" "1" -}}
+  {{- $userEnv := dict -}}
+  {{- if kindIs "map" .Values.web.env -}}
+  {{- $userEnv = .Values.web.env -}}
+  {{- end -}}
+  {{- $env := merge (deepCopy $defaults) $userEnv -}}
+  {{- range $k, $v := $env }}
+  {{ $k }}: {{ $v | toString | quote }}
+  {{- end }}

--- a/charts/nextjs/templates/web-env-secret.yaml
+++ b/charts/nextjs/templates/web-env-secret.yaml
@@ -5,8 +5,25 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 data:
-  {{- if .Values.web.extraEnvs }}
-  {{- range $index, $map := .Values.web.extraEnvs }}
-  {{ $map.name | upper | replace "-" "_" }}: {{ $map.value | toString | b64enc | quote }}
-  {{- end }}
+  {{- $secretEnv := dict -}}
+
+  {{- /* Back-compat: extraEnvs is a list of {name,value}. */ -}}
+  {{- if kindIs "slice" .Values.web.extraEnvs -}}
+  {{- range $_, $item := .Values.web.extraEnvs -}}
+  {{- $name := (default "" $item.name) | toString -}}
+  {{- if $name -}}
+  {{- $_ := set $secretEnv ($name | upper | replace "-" "_") (($item.value | toString)) -}}
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+
+  {{- /* New: secretEnv is a map of env var name => value. */ -}}
+  {{- if kindIs "map" .Values.web.secretEnv -}}
+  {{- range $k, $v := .Values.web.secretEnv -}}
+  {{- $_ := set $secretEnv (($k | toString) | upper | replace "-" "_") ($v | toString) -}}
+  {{- end -}}
+  {{- end -}}
+
+  {{- range $k, $v := $secretEnv }}
+  {{ $k }}: {{ $v | b64enc | quote }}
   {{- end }}

--- a/charts/nextjs/values.yaml
+++ b/charts/nextjs/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ''
 
 web:
   imagePullPolicy: IfNotPresent
-  imagePullSecrets: '' # must be present in namespace
+  imagePullSecrets: ''  # must be present in namespace
   image: ''
   terminationGracePeriodSeconds: 0
   replicaCount: 1
@@ -62,26 +62,26 @@ web:
   # not sure about the usefulness of this - we are trying to solve some caching issues with next.js
   # so this should be considered experimental.
   cachePersistentVolume:
-    enabled: false # If set to true, a PersistentVolumeClaim (PVC) will be created for caching
-    storageClass: '' # The storage class to use for the PVC. If not set, the default StorageClass will be used
-    existingClaim: '' # If set, this existing PVC will be used instead of creating a new one
+    enabled: false  # If set to true, a PersistentVolumeClaim (PVC) will be created for caching
+    storageClass: ''  # The storage class to use for the PVC. If not set, the default StorageClass will be used
+    existingClaim: ''  # If set, this existing PVC will be used instead of creating a new one
     accessModes:
-      - ReadWriteOnce # The access modes for the PVC. Can be ReadWriteOnce, ReadOnlyMany, or ReadWriteMany. If cachePersistentVolume is enabled and replicaCount is more than 1, this should be set to ReadWriteMany
-    annotations: {} # Annotations to add to the PVC
-    size: 1Gi # The requested storage size for the PVC
-    volumeMode: '' # The volume mode for the PVC. Can be either "Filesystem" (default) or "Block"
-    mountPath: /app/.next/cache # The path to mount the volume in the container
+      - ReadWriteOnce  # The access modes for the PVC. Can be ReadWriteOnce, ReadOnlyMany, or ReadWriteMany. If cachePersistentVolume is enabled and replicaCount is more than 1, this should be set to ReadWriteMany
+    annotations: {}  # Annotations to add to the PVC
+    size: 1Gi  # The requested storage size for the PVC
+    volumeMode: ''  # The volume mode for the PVC. Can be either "Filesystem" (default) or "Block"
+    mountPath: /app/.next/cache  # The path to mount the volume in the container
 
   dataVolume:
-    enabled: false # If set to true, a PersistentVolumeClaim (PVC) will be created
-    storageClass: '' # The storage class to use for the PVC. If not set, the default StorageClass will be used
-    existingClaim: '' # If set, this existing PVC will be used instead of creating a new one
+    enabled: false  # If set to true, a PersistentVolumeClaim (PVC) will be created
+    storageClass: ''  # The storage class to use for the PVC. If not set, the default StorageClass will be used
+    existingClaim: ''  # If set, this existing PVC will be used instead of creating a new one
     accessModes:
-      - ReadWriteOnce # The access modes for the PVC. Can be ReadWriteOnce, ReadOnlyMany, or ReadWriteMany. If dataVolume is enabled and replicaCount is more than 1, this should be set to ReadWriteMany
-    annotations: {} # Annotations to add to the PVC
-    size: 1Gi # The requested storage size for the PVC
-    volumeMode: '' # The volume mode for the PVC. Can be either "Filesystem" (default) or "Block"
-    mountPath: /app/data # The path to mount the volume in the container
+      - ReadWriteOnce  # The access modes for the PVC. Can be ReadWriteOnce, ReadOnlyMany, or ReadWriteMany. If dataVolume is enabled and replicaCount is more than 1, this should be set to ReadWriteMany
+    annotations: {}  # Annotations to add to the PVC
+    size: 1Gi  # The requested storage size for the PVC
+    volumeMode: ''  # The volume mode for the PVC. Can be either "Filesystem" (default) or "Block"
+    mountPath: /app/data  # The path to mount the volume in the container
 
   hpa:
     enabled: false
@@ -139,6 +139,18 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+  # env -- Non-secret env vars stored in the chart-managed ConfigMap.
+  # Merged on top of the default envs (AWS_SDK_CONFIG_OPT_OUT, NEXT_TELEMETRY_DISABLED).
+  # web.env:
+  #   NEXT_PUBLIC_API_BASE: https://api.example.com
+  env: {}
+
+  # secretEnv -- Secret env vars stored in the chart-managed Secret.
+  # Keys are normalized to uppercase and '-' is replaced with '_' (same behavior as extraEnvs).
+  # web.secretEnv:
+  #   NEXTAUTH_SECRET: xxxx
+  secretEnv: {}
 
   extraEnvs: []
   # extraEnvs:


### PR DESCRIPTION
Supersedes #20.

What
- Add `web.env` (map) for non-secret env vars stored in the chart-managed ConfigMap.
- Add `web.secretEnv` (map) for secret env vars stored in the chart-managed Secret.
- Preserve existing `web.extraEnvs` list-of-objects behavior (back-compat); values are merged into the Secret.
- Keep default envs (`AWS_SDK_CONFIG_OPT_OUT`, `NEXT_TELEMETRY_DISABLED`) and allow overriding via `web.env`.

Why
- #20 attempted to add map-style envs but was backwards-incompatible and could break pods by conditionally omitting the Secret while still referencing it from the Deployment.

Release
- Bump chart version: 1.1.13 -> 1.1.14.

Validation
- `helm lint charts/nextjs`
- `helm template ...` + `kubeconform`
- `ct lint --target-branch main` (via chart-testing container)