### PR TITLE
test(nextjs): add ct install values (web.image)

### DIFF
--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nextjs
 description: Generic Helm chart for Nextjs apps on Kubernetes
 type: application
-version: 1.1.14
+version: 1.1.15
 appVersion: '1.0.0'
 icon: https://icoretech.github.io/helm/charts/nextjs/logo.png
 keywords:

--- a/charts/nextjs/Readme.md
+++ b/charts/nextjs/Readme.md
@@ -1,6 +1,6 @@
 # nextjs
 
-![Version: 1.1.14](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.15](https://img.shields.io/badge/Version-1.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for Nextjs apps on Kubernetes
 

--- a/charts/nextjs/ci/install-values.yaml
+++ b/charts/nextjs/ci/install-values.yaml
@@ -1,0 +1,4 @@
+# Values used by chart-testing (ct install) to ensure the chart can be installed.
+# The chart requires web.image; we use a harmless public image.
+web:
+  image: nginx:latest


### PR DESCRIPTION
Add `charts/nextjs/ci/install-values.yaml` used by chart-testing so `ct install` can succeed without extra args.

- Sets `web.image: nginx:latest` (harmless public image).
- Bumps chart version: 1.1.14 -> 1.1.15 (required by ct version gate).

Local validation
- `ct lint --target-branch main`
- `ct install --charts charts/nextjs` against Docker Desktop Kubernetes (via mounted kubeconfig).