### PR TITLE
chore(nextjs): default web.image to nginx

### DIFF
--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nextjs
 description: Generic Helm chart for Nextjs apps on Kubernetes
 type: application
-version: 1.1.15
+version: 1.1.16
 appVersion: '1.0.0'
 icon: https://icoretech.github.io/helm/charts/nextjs/logo.png
 keywords:

--- a/charts/nextjs/Readme.md
+++ b/charts/nextjs/Readme.md
@@ -1,6 +1,6 @@
 # nextjs
 
-![Version: 1.1.15](https://img.shields.io/badge/Version-1.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.16](https://img.shields.io/badge/Version-1.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Generic Helm chart for Nextjs apps on Kubernetes
 
@@ -48,7 +48,7 @@ Generic Helm chart for Nextjs apps on Kubernetes
 | web.hpa.maxReplicas | int | `10` |  |
 | web.hpa.memory | string | `nil` |  |
 | web.hpa.requests | string | `nil` |  |
-| web.image | string | `""` |  |
+| web.image | string | `"nginx:latest"` |  |
 | web.imagePullPolicy | string | `"IfNotPresent"` |  |
 | web.imagePullSecrets | string | `""` |  |
 | web.ingress.annotations | object | `{}` |  |

--- a/charts/nextjs/values.yaml
+++ b/charts/nextjs/values.yaml
@@ -4,7 +4,8 @@ fullnameOverride: ''
 web:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: ''  # must be present in namespace
-  image: ''
+  # image -- Container image for the app. Override this for your Next.js image.
+  image: nginx:latest
   terminationGracePeriodSeconds: 0
   replicaCount: 1
   runtimeClassName:


### PR DESCRIPTION
Set a safe default `web.image` so the chart is installable out-of-the-box and Artifact Hub can detect an image. Users are expected to override this with their own app image.

- Default `web.image: nginx:latest`
- Chart version bump: 1.1.15 -> 1.1.16

Validation
- `helm lint charts/nextjs`
- `helm template` + `kubeconform`
- `ct lint --target-branch main`
- `ct install --charts charts/nextjs` against Docker Desktop Kubernetes (via mounted kubeconfig)