### PR TITLE
feat(pgbouncer): exporter can use separate auth secret

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying PgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 4.1.0
+version: 4.1.1
 appVersion: 1.25.1
 kubeVersion: ">= 1.31.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png
@@ -11,7 +11,7 @@ keywords:
   - postgresql
   - kubernetes
 maintainers:
-  - name: Claudio Poli
+  - name: masterkain
     email: claudio@icorete.ch
     url: https://github.com/masterkain
 home: https://github.com/icoretech/helm

--- a/charts/pgbouncer/README.md
+++ b/charts/pgbouncer/README.md
@@ -55,13 +55,16 @@ The following table lists the configurable parameters of the PgBouncer chart and
 | image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy: Always, IfNotPresent, or Never |
 | image.registry | string | `""` | Container image registry |
 | image.repository | string | `"ghcr.io/icoretech/pgbouncer-docker"` | Container image repository |
-| image.tag | string | `"1.24.1"` | Container image tag |
+| image.tag | string | `"1.25.1"` | Container image tag |
 | imagePullSecrets | list | `[]` | Array of imagePullSecrets to use for pulling private images. |
 | kind | string | `"Deployment"` | Resource type for PgBouncer (Deployment, DaemonSet). Defaults to Deployment. |
 | lifecycle | object | `{}` | See Kubernetes docs on lifecycle hooks. |
 | minReadySeconds | int | `0` | Minimum number of seconds for which a newly created pod should be ready without crashing, before being considered available. |
 | nameOverride | string | `""` | Overrides the chart name for resources. If set, takes precedence over the chart's name. |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
+| pgbouncerExporter.auth.existingSecret | string | `""` | If set, the exporter will read credentials from this Secret instead of config.existingAdminSecret. This allows using a separate, lower-privilege stats user. Leave empty to preserve current behavior. |
+| pgbouncerExporter.auth.passwordKey | string | `"adminPassword"` | Secret key for the exporter password (only used when auth.existingSecret is set). |
+| pgbouncerExporter.auth.userKey | string | `"adminUser"` | Secret key for the exporter username (only used when auth.existingSecret is set). |
 | pgbouncerExporter.connect_timeout | int | `10` |  |
 | pgbouncerExporter.database | string | `"pgbouncer"` |  |
 | pgbouncerExporter.enabled | bool | `false` | Enable or disable the PgBouncer exporter sidecar container. |
@@ -93,6 +96,8 @@ The following table lists the configurable parameters of the PgBouncer chart and
 | service.internalTrafficPolicy | string | `"Cluster"` | Internal traffic policy for the Service (Cluster or Local). |
 | service.nodePort | string | `nil` | Set service nodePort, can be null |
 | service.port | int | `5432` | The service port for PgBouncer. |
+| service.sessionAffinity | string | `"None"` | If "ClientIP", consecutive client requests will be directed to the same Pod |
+| service.sessionAffinityConfig | object | `{}` | sessionAffinityConfig Additional settings for the sessionAffinity sessionAffinityConfig:   clientIP:     timeoutSeconds: 180 |
 | service.type | string | `"ClusterIP"` | Service type (e.g. ClusterIP, NodePort, LoadBalancer). |
 | serviceAccount.annotations | object | `{}` | Annotations for the created ServiceAccount. |
 | serviceAccount.name | string | `""` | Creates a new ServiceAccount if this is empty. |

--- a/charts/pgbouncer/ci/install-values.yaml
+++ b/charts/pgbouncer/ci/install-values.yaml
@@ -1,0 +1,4 @@
+# Values used by chart-testing (ct install) to ensure the chart can be installed.
+# The chart requires an admin password when creating the admin Secret.
+config:
+  adminPassword: changeme

--- a/charts/pgbouncer/templates/daemonset.yaml
+++ b/charts/pgbouncer/templates/daemonset.yaml
@@ -1,4 +1,9 @@
 {{- if eq .Values.kind "DaemonSet" }}
+{{- $exporterAuthSecret := .Values.pgbouncerExporter.auth.existingSecret | default "" -}}
+{{- $adminSecretName := .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) -}}
+{{- $exporterSecretName := ternary $exporterAuthSecret $adminSecretName (ne $exporterAuthSecret "") -}}
+{{- $exporterUserKey := ternary (.Values.pgbouncerExporter.auth.userKey | default "adminUser") (.Values.config.adminUserKey | default "adminUser") (ne $exporterAuthSecret "") -}}
+{{- $exporterPasswordKey := ternary (.Values.pgbouncerExporter.auth.passwordKey | default "adminPassword") (.Values.config.adminPasswordKey | default "adminPassword") (ne $exporterAuthSecret "") -}}
 apiVersion: {{ template "deployment.apiVersion" . }}
 kind: DaemonSet
 metadata:
@@ -143,23 +148,23 @@ spec:
         - name: PGBOUNCER_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminUserKey | default "adminUser" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterUserKey }}
         - name: PGBOUNCER_PASS
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminPasswordKey | default "adminPassword" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterPasswordKey }}
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminUserKey | default "adminUser" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterUserKey }}
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminPasswordKey | default "adminPassword" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterPasswordKey }}
         {{- if .Values.pgbouncerExporter.resources }}
         resources: {{ toYaml .Values.pgbouncerExporter.resources | trimSuffix "\n" | nindent 10 }}
         {{- end }}

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -1,4 +1,9 @@
 {{- if eq .Values.kind "Deployment" }}
+{{- $exporterAuthSecret := .Values.pgbouncerExporter.auth.existingSecret | default "" -}}
+{{- $adminSecretName := .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) -}}
+{{- $exporterSecretName := ternary $exporterAuthSecret $adminSecretName (ne $exporterAuthSecret "") -}}
+{{- $exporterUserKey := ternary (.Values.pgbouncerExporter.auth.userKey | default "adminUser") (.Values.config.adminUserKey | default "adminUser") (ne $exporterAuthSecret "") -}}
+{{- $exporterPasswordKey := ternary (.Values.pgbouncerExporter.auth.passwordKey | default "adminPassword") (.Values.config.adminPasswordKey | default "adminPassword") (ne $exporterAuthSecret "") -}}
 apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -150,23 +155,23 @@ spec:
         - name: PGBOUNCER_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminUserKey | default "adminUser" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterUserKey }}
         - name: PGBOUNCER_PASS
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminPasswordKey | default "adminPassword" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterPasswordKey }}
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminUserKey | default "adminUser" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterUserKey }}
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.config.existingAdminSecret | default (printf "%s-secret" (include "pgbouncer.fullname" .)) }}
-              key: {{ .Values.config.adminPasswordKey | default "adminPassword" }}
+              name: {{ $exporterSecretName }}
+              key: {{ $exporterPasswordKey }}
         {{- if .Values.pgbouncerExporter.resources }}
         resources: {{ toYaml .Values.pgbouncerExporter.resources | trimSuffix "\n" | nindent 10 }}
         {{- end }}

--- a/charts/pgbouncer/templates/pdb.yaml
+++ b/charts/pgbouncer/templates/pdb.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.maxUnavailable .Values.podDisruptionBudget.minAvailable }}
+{{- fail "podDisruptionBudget.maxUnavailable and podDisruptionBudget.minAvailable are mutually exclusive" }}
+{{- end }}
 apiVersion: {{ template "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -244,6 +244,14 @@ pgbouncerExporter:
   imagePullSecrets: []
   # -- Whether to create a PodMonitor for scraping metrics (Prometheus Operator).
   podMonitor: false
+  auth:
+    # -- If set, the exporter will read credentials from this Secret instead of config.existingAdminSecret.
+    # This allows using a separate, lower-privilege stats user. Leave empty to preserve current behavior.
+    existingSecret: ""
+    # -- Secret key for the exporter username (only used when auth.existingSecret is set).
+    userKey: adminUser
+    # -- Secret key for the exporter password (only used when auth.existingSecret is set).
+    passwordKey: adminPassword
   host: 127.0.0.1
   port: 5432
   database: pgbouncer


### PR DESCRIPTION
Supersedes #30 (which is conflicting/outdated and not back-compatible).

What
- Add optional `pgbouncerExporter.auth.existingSecret` (+ `userKey`/`passwordKey`) for exporter credentials.
- Default behavior unchanged: exporter continues to use `config.existingAdminSecret`/generated admin secret when `auth.existingSecret` is empty.
- Add `charts/pgbouncer/ci/install-values.yaml` so `ct install` can run (provides a dummy admin password).
- Add a hard guard: fail template if both PDB fields are set (Kubernetes disallows both).
- Bump chart version: 4.1.0 -> 4.1.1.
- Fix Chart maintainer name for ct validation.

How To Use
- Create a Secret with keys matching `userKey`/`passwordKey` (defaults `adminUser`/`adminPassword`) and set `pgbouncerExporter.auth.existingSecret`.
- Also ensure PgBouncer allows that user for stats if needed (e.g. set `config.pgbouncer.stats_users` and add the user to `config.userlist`).

Validation (local)
- `helm lint charts/pgbouncer`
- `helm template` + `kubeconform`
- `ct lint --target-branch main`
- `ct install --charts charts/pgbouncer` against Docker Desktop Kubernetes