### PR TITLE
fix(release): import GPG key for chart signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,26 @@ jobs:
           fi
 
           mkdir -p .cr-gpg
-          echo "$GPG_KEYRING_BASE64" | base64 -d > .cr-gpg/secring.gpg
-          chmod 600 .cr-gpg/secring.gpg
+          echo "$GPG_KEYRING_BASE64" | base64 -d > .cr-gpg/private.key
+          chmod 600 .cr-gpg/private.key
+
+          # Import signing key into a dedicated GPG homedir so helm/cr can find the private key.
+          GNUPGHOME="$PWD/.gnupg"
+          mkdir -p "$GNUPGHOME"
+          chmod 700 "$GNUPGHOME"
+          gpg --batch --homedir "$GNUPGHOME" --import .cr-gpg/private.key
+
+          # Helm expects a GPG keyring file in legacy .gpg format (not pubring.kbx).
+          gpg --batch --homedir "$GNUPGHOME" --yes \
+            --output "$PWD/.cr-gpg/pubring.gpg" \
+            --export "$GPG_SIGNING_KEY"
+          chmod 600 .cr-gpg/pubring.gpg
 
           {
             echo "CR_SIGN=true"
             echo "CR_KEY=$GPG_SIGNING_KEY"
-            echo "CR_KEYRING=$PWD/.cr-gpg/secring.gpg"
+            echo "CR_KEYRING=$PWD/.cr-gpg/pubring.gpg"
+            echo "GNUPGHOME=$GNUPGHOME"
           } >> "$GITHUB_ENV"
 
           echo "enabled=true" >> "$GITHUB_OUTPUT"

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -11,7 +11,7 @@ This repository signs Helm chart packages (`.tgz`) with Helm provenance (`.prov`
 
 ## GitHub Actions Secrets
 The release workflow expects these repo secrets:
-- `GPG_KEYRING_BASE64`: base64 of a GPG secret keyring file (`secring.gpg`) containing the signing key.
+- `GPG_KEYRING_BASE64`: base64 of an exported GPG private key file (for example from `gpg --export-secret-keys`).
 - `GPG_SIGNING_KEY`: the signing key identifier (recommended: full fingerprint).
 
 If chart versions are bumped in a push to `main` and signing secrets are missing, the release workflow will fail intentionally to avoid publishing unsigned chart versions.
@@ -27,4 +27,3 @@ helm pull icoretech/<chart> --version <version> --prov
 curl -fsSL https://icoretech.github.io/helm/pgp-public-key.asc | gpg --import
 helm verify <chart>-<version>.tgz
 ```
-


### PR DESCRIPTION
Fix Release Charts signing: chart-releaser/helm requires the private key to be importable by GPG. The previous workflow only wrote the exported secret key file to disk and passed it as `CR_KEYRING`, which resulted in `private key not found`.

Changes:
- Import `GPG_KEYRING_BASE64` into a dedicated `GNUPGHOME`.
- Generate a legacy `pubring.gpg` file and pass it as `CR_KEYRING`.

After merge, re-run of `Release Charts` should produce `.prov` files and complete the previously failed release.
