### PR TITLE
fix(release): use secret keyring for helm signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,16 +52,12 @@ jobs:
           chmod 700 "$GNUPGHOME"
           gpg --batch --homedir "$GNUPGHOME" --import .cr-gpg/private.key
 
-          # Helm expects a GPG keyring file in legacy .gpg format (not pubring.kbx).
-          gpg --batch --homedir "$GNUPGHOME" --yes \
-            --output "$PWD/.cr-gpg/pubring.gpg" \
-            --export "$GPG_SIGNING_KEY"
-          chmod 600 .cr-gpg/pubring.gpg
-
           {
             echo "CR_SIGN=true"
             echo "CR_KEY=$GPG_SIGNING_KEY"
-            echo "CR_KEYRING=$PWD/.cr-gpg/pubring.gpg"
+            # cr/helm expects CR_KEYRING to point at a keyring that contains the secret key.
+            # We use an exported secret key file produced by `gpg --export-secret-keys`.
+            echo "CR_KEYRING=$PWD/.cr-gpg/private.key"
             echo "GNUPGHOME=$GNUPGHOME"
           } >> "$GITHUB_ENV"
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -11,7 +11,7 @@ This repository signs Helm chart packages (`.tgz`) with Helm provenance (`.prov`
 
 ## GitHub Actions Secrets
 The release workflow expects these repo secrets:
-- `GPG_KEYRING_BASE64`: base64 of an exported GPG private key file (for example from `gpg --export-secret-keys`).
+- `GPG_KEYRING_BASE64`: base64 of an exported GPG secret key file (for example from `gpg --export-secret-keys`). This file must contain the private key and is passed to the release tooling as the signing keyring.
 - `GPG_SIGNING_KEY`: the signing key identifier (recommended: full fingerprint).
 
 If chart versions are bumped in a push to `main` and signing secrets are missing, the release workflow will fail intentionally to avoid publishing unsigned chart versions.


### PR DESCRIPTION
The `Release Charts` workflow still failed signing with: `provided key is not a private key`.

Root cause: `cr package` (and/or `helm package --sign`) expects `--keyring` to point at a keyring that contains the secret key material. Passing a public-only keyring doesn't work.

Change:
- Keep importing the secret key into `GNUPGHOME` for completeness, but set `CR_KEYRING` to the decoded secret key export file (`.cr-gpg/private.key`).

This should allow chart-releaser to produce `.prov` files and complete the release.
