### PR TITLE
feat(metamcp): support imagePullSecrets in deployment

### DIFF
--- a/charts/metamcp/Chart.yaml
+++ b/charts/metamcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metamcp
 description: MetaMCP aggregator Helm chart for Kubernetes
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "2.4.22"
 icon: https://icoretech.github.io/helm/charts/metamcp/logo.png
 keywords:

--- a/charts/metamcp/README.md
+++ b/charts/metamcp/README.md
@@ -211,7 +211,7 @@ provision:
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/metatool-ai/metamcp"` |  |
 | image.tag | string | `"2.4.22"` |  |
-| imagePullSecrets | list | `[]` |  |
+| imagePullSecrets | list | `[]` | imagePullSecrets allows pulling the MetaMCP image from private registries. Example: imagePullSecrets:   - name: regcred |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/metamcp/templates/deployment.yaml
+++ b/charts/metamcp/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "metamcp.fullname" . }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- $hasDBURL := and (kindIs "map" .Values.env) (hasKey .Values.env "DATABASE_URL") }}
       {{- if not $hasDBURL }}
       {{- /* only use init container when using internal postgres */}}

--- a/charts/metamcp/values.yaml
+++ b/charts/metamcp/values.yaml
@@ -9,6 +9,10 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.4.22
 
+# -- imagePullSecrets allows pulling the MetaMCP image from private registries.
+# Example:
+# imagePullSecrets:
+#   - name: regcred
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## What
Implement issue #46 by wiring `imagePullSecrets` into the `metamcp` Deployment pod spec.

## Why
`charts/metamcp/values.yaml` already exposed `imagePullSecrets`, but `templates/deployment.yaml` did not apply it, so private registry pulls for the main MetaMCP pod could not be configured.

## Changes
- `charts/metamcp/templates/deployment.yaml`
  - Add pod-level `imagePullSecrets` support using `.Values.imagePullSecrets`.
- `charts/metamcp/values.yaml`
  - Add documented example/guidance for `imagePullSecrets`.
- `charts/metamcp/README.md`
  - Regenerated values table to include the `imagePullSecrets` description.
- `charts/metamcp/Chart.yaml`
  - Bump chart version `0.2.3 -> 0.2.4`.

## Validation
- `helm lint charts/metamcp`
- `helm template t charts/metamcp -f charts/metamcp/values.yaml`
- `helm template t charts/metamcp -f charts/metamcp/values.yaml -f /tmp/metamcp-pullsecret-values.yaml` (verified `imagePullSecrets` rendered)
- `kubeconform -kubernetes-version 1.31.0 /tmp/rendered-metamcp-default.yaml`
- `ct lint --target-branch main` (dockerized)
- `ct install --target-branch main` (dockerized, docker-desktop kubecontext)

Closes #46.
