### PR TITLE
feat(tolgee): support manually-defined postgres connection env vars

### DIFF
--- a/charts/tolgee/README.md
+++ b/charts/tolgee/README.md
@@ -175,6 +175,7 @@ spec:
 | database.external.existingSecret.usernameKey | string | `"SPRING_DATASOURCE_USERNAME"` | Key for DB username. |
 | database.external.host | string | `""` | External PostgreSQL host. |
 | database.external.jdbcUrl | string | `""` | Full external JDBC URL override. |
+| database.external.manualEnvs | bool | `false` | Do not generate `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, or `SPRING_DATASOURCE_PASSWORD`. Use this when datasource env vars are supplied manually through `tolgee.extraEnv`. |
 | database.external.name | string | `"tolgee"` | External PostgreSQL database name. |
 | database.external.password | string | `""` | External PostgreSQL password. |
 | database.external.port | int | `5432` | External PostgreSQL port. |

--- a/charts/tolgee/templates/deployment.yaml
+++ b/charts/tolgee/templates/deployment.yaml
@@ -86,6 +86,7 @@ spec:
               value: {{ .Values.tolgee.fileStorage.fsDataPath | quote }}
             {{- $_ := set $envSeen "TOLGEE_FILE_STORAGE_FS_DATA_PATH" true }}
 
+            {{- if not .Values.database.external.manualEnvs }}
             {{- if and .Values.database.external.enabled .Values.database.external.existingSecret.name }}
             - name: SPRING_DATASOURCE_URL
               valueFrom:
@@ -113,6 +114,7 @@ spec:
             {{- $_ := set $envSeen "SPRING_DATASOURCE_URL" true }}
             {{- $_ := set $envSeen "SPRING_DATASOURCE_USERNAME" true }}
             {{- $_ := set $envSeen "SPRING_DATASOURCE_PASSWORD" true }}
+            {{- end }}
 
             {{- with .Values.tolgee.frontEndUrl }}
             - name: TOLGEE_FRONT_END_URL

--- a/charts/tolgee/values.schema.json
+++ b/charts/tolgee/values.schema.json
@@ -235,7 +235,8 @@
                 "passwordKey": { "type": "string" }
               },
               "required": ["name", "urlKey", "usernameKey", "passwordKey"]
-            }
+            },
+            "manualEnvs": { "type": "boolean" }
           },
           "required": ["enabled", "port", "name", "existingSecret"]
         },
@@ -535,6 +536,22 @@
                       "external": {
                         "type": "object",
                         "properties": {
+                          "manualEnvs": { "const": true }
+                        },
+                        "required": ["manualEnvs"]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "database": {
+                    "type": "object",
+                    "properties": {
+                      "external": {
+                        "type": "object",
+                        "properties": {
                           "existingSecret": {
                             "type": "object",
                             "properties": {
@@ -609,7 +626,8 @@
               "external": {
                 "type": "object",
                 "properties": {
-                  "enabled": { "const": true }
+                  "enabled": { "const": true },
+                  "manualEnvs": { "not": { "const": true } }
                 },
                 "required": ["enabled"]
               },

--- a/charts/tolgee/values.yaml
+++ b/charts/tolgee/values.yaml
@@ -275,6 +275,12 @@ database:
       # -- Key for DB password.
       passwordKey: SPRING_DATASOURCE_PASSWORD
 
+    # -- Do not generate SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME,
+    # -- or SPRING_DATASOURCE_PASSWORD. Use this when datasource env vars are
+    # -- supplied manually through tolgee.extraEnv, for example when composing
+    # -- a JDBC URL from multiple secretKeyRef-backed environment variables.
+    manualEnvs: false
+
   waitForReady:
     # -- Wait for PostgreSQL TCP readiness before starting Tolgee.
     enabled: true


### PR DESCRIPTION
## Summary

Add `database.external.manualEnvs` to allow users to provide Spring datasource environment variables manually through `tolgee.extraEnv`.
Resolves #140 

## Motivation

Some infrastructure provisioning pipelines generate database connection details across multiple Kubernetes Secrets. For example, one Secret may contain the database hostname while another contains database name, username, and password. In that model, the final JDBC URL must be composed at runtime using Kubernetes environment variable expansion from `secretKeyRef` values.

The current chart always renders `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, and `SPRING_DATASOURCE_PASSWORD` before `tolgee.extraEnv`, and marks them as already seen. This prevents users from supplying these env vars manually through `tolgee.extraEnv`.

## Change

When `database.external.manualEnvs=true`, the chart skips rendering:

- `SPRING_DATASOURCE_URL`
- `SPRING_DATASOURCE_USERNAME`
- `SPRING_DATASOURCE_PASSWORD`

and does not add them to the internal `envSeen` map. This allows users to define them through `tolgee.extraEnv`.

Default behavior is unchanged.

## Example `values.yaml`

```yaml
postgres:
  enabled: false

database:
  external:
    enabled: true
    manualEnvs: true
  waitForReady:
    enabled: false

tolgee:
  extraEnv:
    - name: AURORA_HOSTNAME
      valueFrom:
        secretKeyRef:
          name: tolgee-aurora
          key: AURORA_HOSTNAME

    - name: TOLGEE_DB_NAME
      valueFrom:
        secretKeyRef:
          name: tolgee-db-creds
          key: database

    - name: SPRING_DATASOURCE_USERNAME
      valueFrom:
        secretKeyRef:
          name: tolgee-db-creds
          key: username

    - name: SPRING_DATASOURCE_PASSWORD
      valueFrom:
        secretKeyRef:
          name: tolgee-db-creds
          key: password

    - name: SPRING_DATASOURCE_URL
      value: "jdbc:postgresql://$(AURORA_HOSTNAME):5432/$(TOLGEE_DB_NAME)?sslmode=require&reWriteBatchedInserts=true"
```