### PR TITLE
feat(tolgee): support datasource valueFrom sources

### DIFF
--- a/charts/tolgee/Chart.yaml
+++ b/charts/tolgee/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tolgee
 description: Tolgee Platform Helm chart for Kubernetes
 type: application
-version: 0.17.0
+version: 0.18.0
 appVersion: "v3.183.0"
 kubeVersion: ">= 1.24.0-0"
 icon: https://icoretech.github.io/helm/charts/tolgee/logo.svg

--- a/charts/tolgee/README.md
+++ b/charts/tolgee/README.md
@@ -80,6 +80,44 @@ database:
 
 or set `database.external.host` so the initContainer can probe DB readiness.
 
+## External PostgreSQL Values from Multiple Secrets
+
+Use `database.external.extraEnv` for helper values that must be available before
+Kubernetes expands `database.external.jdbcUrl`. Keep the `SPRING_DATASOURCE_*`
+names owned by the chart through `jdbcUrl`/`jdbcUrlFrom`, `username`/`usernameFrom`,
+and `password`/`passwordFrom`.
+
+```yaml
+postgres:
+  enabled: false
+
+database:
+  external:
+    enabled: true
+    extraEnv:
+      - name: AURORA_HOSTNAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-aurora
+            key: hostname
+      - name: TOLGEE_DB_NAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-db-creds
+            key: database
+    jdbcUrl: "jdbc:postgresql://$(AURORA_HOSTNAME):5432/$(TOLGEE_DB_NAME)?sslmode=require"
+    usernameFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: username
+    passwordFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: password
+  waitForReady:
+    enabled: false
+```
+
 ## Sensitive Values via Secret Refs
 
 Use the built-in `*Ref` fields when you want chart-managed env wiring without storing clear-text values in Helm values:
@@ -173,12 +211,16 @@ spec:
 | database.external.existingSecret.passwordKey | string | `"SPRING_DATASOURCE_PASSWORD"` | Key for DB password. |
 | database.external.existingSecret.urlKey | string | `"SPRING_DATASOURCE_URL"` | Key for JDBC URL. |
 | database.external.existingSecret.usernameKey | string | `"SPRING_DATASOURCE_USERNAME"` | Key for DB username. |
+| database.external.extraEnv | list | `[]` | Extra env vars rendered before SPRING_DATASOURCE_* for external DB URL expansion. |
 | database.external.host | string | `""` | External PostgreSQL host. |
 | database.external.jdbcUrl | string | `""` | Full external JDBC URL override. |
+| database.external.jdbcUrlFrom | object | `{}` | Kubernetes valueFrom source for SPRING_DATASOURCE_URL. |
 | database.external.name | string | `"tolgee"` | External PostgreSQL database name. |
 | database.external.password | string | `""` | External PostgreSQL password. |
+| database.external.passwordFrom | object | `{}` | Kubernetes valueFrom source for SPRING_DATASOURCE_PASSWORD. |
 | database.external.port | int | `5432` | External PostgreSQL port. |
 | database.external.username | string | `""` | External PostgreSQL username. |
+| database.external.usernameFrom | object | `{}` | Kubernetes valueFrom source for SPRING_DATASOURCE_USERNAME. |
 | database.internal.port | int | `5432` | Internal PostgreSQL service port. |
 | database.internal.serviceName | string | `""` | Override internal PostgreSQL service name (defaults to <release>-postgres). |
 | database.jdbcParameters | string | `"reWriteBatchedInserts=true"` | Extra JDBC query parameters (without leading ?), e.g. key1=value1&key2=value2. |

--- a/charts/tolgee/README.md.gotmpl
+++ b/charts/tolgee/README.md.gotmpl
@@ -80,6 +80,44 @@ database:
 
 or set `database.external.host` so the initContainer can probe DB readiness.
 
+## External PostgreSQL Values from Multiple Secrets
+
+Use `database.external.extraEnv` for helper values that must be available before
+Kubernetes expands `database.external.jdbcUrl`. Keep the `SPRING_DATASOURCE_*`
+names owned by the chart through `jdbcUrl`/`jdbcUrlFrom`, `username`/`usernameFrom`,
+and `password`/`passwordFrom`.
+
+```yaml
+postgres:
+  enabled: false
+
+database:
+  external:
+    enabled: true
+    extraEnv:
+      - name: AURORA_HOSTNAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-aurora
+            key: hostname
+      - name: TOLGEE_DB_NAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-db-creds
+            key: database
+    jdbcUrl: "jdbc:postgresql://$(AURORA_HOSTNAME):5432/$(TOLGEE_DB_NAME)?sslmode=require"
+    usernameFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: username
+    passwordFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: password
+  waitForReady:
+    enabled: false
+```
+
 ## Sensitive Values via Secret Refs
 
 Use the built-in `*Ref` fields when you want chart-managed env wiring without storing clear-text values in Helm values:

--- a/charts/tolgee/scripts/test-schema.sh
+++ b/charts/tolgee/scripts/test-schema.sh
@@ -12,6 +12,7 @@ for f in \
   tests/values/valid-minimal.yaml \
   tests/values/valid-external.yaml \
   tests/values/valid-external-secret.yaml \
+  tests/values/valid-external-valuefrom.yaml \
   tests/values/valid-metrics-servicemonitor.yaml \
   tests/values/valid-s3-secretrefs.yaml
   do
@@ -41,6 +42,7 @@ echo "==> Invalid fixtures must fail"
 for f in \
   tests/values/invalid-both-db-modes.yaml \
   tests/values/invalid-external-missing-creds.yaml \
+  tests/values/invalid-external-reserved-extraenv.yaml \
   tests/values/invalid-external-wait-missing-host.yaml \
   tests/values/invalid-http-route-parents.yaml \
   tests/values/invalid-jwt-secretref-missing-key.yaml \

--- a/charts/tolgee/templates/deployment.yaml
+++ b/charts/tolgee/templates/deployment.yaml
@@ -86,6 +86,26 @@ spec:
               value: {{ .Values.tolgee.fileStorage.fsDataPath | quote }}
             {{- $_ := set $envSeen "TOLGEE_FILE_STORAGE_FS_DATA_PATH" true }}
 
+            {{- if .Values.database.external.enabled }}
+            {{- range $index, $env := .Values.database.external.extraEnv }}
+            {{- $name := default "" $env.name }}
+            {{- if or (eq $name "SPRING_DATASOURCE_URL") (eq $name "SPRING_DATASOURCE_USERNAME") (eq $name "SPRING_DATASOURCE_PASSWORD") }}
+            {{- fail (printf "tolgee: database.external.extraEnv[%d].name=%s is reserved; use database.external.jdbcUrl/jdbcUrlFrom, username/usernameFrom, or password/passwordFrom instead" $index $name) }}
+            {{- end }}
+            {{- if and (ne $name "") (not (hasKey $envSeen $name)) }}
+            - name: {{ $name | quote }}
+              {{- if hasKey $env "value" }}
+              value: {{ $env.value | quote }}
+              {{- end }}
+              {{- if hasKey $env "valueFrom" }}
+              valueFrom:
+                {{- toYaml $env.valueFrom | nindent 16 }}
+              {{- end }}
+            {{- $_ := set $envSeen $name true }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+
             {{- if and .Values.database.external.enabled .Values.database.external.existingSecret.name }}
             - name: SPRING_DATASOURCE_URL
               valueFrom:
@@ -104,11 +124,26 @@ spec:
                   key: {{ .Values.database.external.existingSecret.passwordKey | quote }}
             {{- else }}
             - name: SPRING_DATASOURCE_URL
+              {{- if and .Values.database.external.enabled .Values.database.external.jdbcUrlFrom }}
+              valueFrom:
+                {{- toYaml .Values.database.external.jdbcUrlFrom | nindent 16 }}
+              {{- else }}
               value: {{ include "tolgee.database.jdbcUrl" . | quote }}
+              {{- end }}
             - name: SPRING_DATASOURCE_USERNAME
+              {{- if and .Values.database.external.enabled .Values.database.external.usernameFrom }}
+              valueFrom:
+                {{- toYaml .Values.database.external.usernameFrom | nindent 16 }}
+              {{- else }}
               value: {{ include "tolgee.database.username" . | quote }}
+              {{- end }}
             - name: SPRING_DATASOURCE_PASSWORD
+              {{- if and .Values.database.external.enabled .Values.database.external.passwordFrom }}
+              valueFrom:
+                {{- toYaml .Values.database.external.passwordFrom | nindent 16 }}
+              {{- else }}
               value: {{ include "tolgee.database.password" . | quote }}
+              {{- end }}
             {{- end }}
             {{- $_ := set $envSeen "SPRING_DATASOURCE_URL" true }}
             {{- $_ := set $envSeen "SPRING_DATASOURCE_USERNAME" true }}

--- a/charts/tolgee/tests/database_external_test.yaml
+++ b/charts/tolgee/tests/database_external_test.yaml
@@ -21,3 +21,25 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].env[?(@.name=="DB_HOST")].value
           value: postgres.example.com
+
+  - it: supports datasource values sourced from multiple secrets
+    values:
+      - values/valid-external-valuefrom.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="AURORA_HOSTNAME")].valueFrom.secretKeyRef.name
+          value: tolgee-aurora
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="TOLGEE_DB_NAME")].valueFrom.secretKeyRef.key
+          value: database
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="SPRING_DATASOURCE_URL")].value
+          value: jdbc:postgresql://$(AURORA_HOSTNAME):5432/$(TOLGEE_DB_NAME)?sslmode=require&reWriteBatchedInserts=true
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="SPRING_DATASOURCE_USERNAME")].valueFrom.secretKeyRef.key
+          value: username
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="SPRING_DATASOURCE_PASSWORD")].valueFrom.secretKeyRef.key
+          value: password
+      - notExists:
+          path: spec.template.spec.initContainers

--- a/charts/tolgee/tests/values/invalid-external-reserved-extraenv.yaml
+++ b/charts/tolgee/tests/values/invalid-external-reserved-extraenv.yaml
@@ -1,0 +1,14 @@
+postgres:
+  enabled: false
+database:
+  external:
+    enabled: true
+    jdbcUrl: "jdbc:postgresql://postgres.example.com:5432/tolgee"
+    username: ext_user
+    password: ext_password
+    extraEnv:
+      - name: SPRING_DATASOURCE_URL
+        value: "jdbc:postgresql://other.example.com:5432/tolgee"
+tolgee:
+  authentication:
+    jwtSecret: "replace-with-a-strong-secret-at-least-32-characters"

--- a/charts/tolgee/tests/values/valid-external-valuefrom.yaml
+++ b/charts/tolgee/tests/values/valid-external-valuefrom.yaml
@@ -1,0 +1,30 @@
+postgres:
+  enabled: false
+database:
+  external:
+    enabled: true
+    jdbcUrl: "jdbc:postgresql://$(AURORA_HOSTNAME):5432/$(TOLGEE_DB_NAME)?sslmode=require&reWriteBatchedInserts=true"
+    usernameFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: username
+    passwordFrom:
+      secretKeyRef:
+        name: tolgee-db-creds
+        key: password
+    extraEnv:
+      - name: AURORA_HOSTNAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-aurora
+            key: hostname
+      - name: TOLGEE_DB_NAME
+        valueFrom:
+          secretKeyRef:
+            name: tolgee-db-creds
+            key: database
+  waitForReady:
+    enabled: false
+tolgee:
+  authentication:
+    jwtSecret: "replace-with-a-strong-secret-at-least-32-characters"

--- a/charts/tolgee/values.schema.json
+++ b/charts/tolgee/values.schema.json
@@ -223,8 +223,34 @@
             "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
             "name": { "type": "string" },
             "username": { "type": "string" },
+            "usernameFrom": { "type": "object" },
             "password": { "type": "string" },
+            "passwordFrom": { "type": "object" },
             "jdbcUrl": { "type": "string" },
+            "jdbcUrlFrom": { "type": "object" },
+            "extraEnv": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "not": {
+                      "enum": [
+                        "SPRING_DATASOURCE_URL",
+                        "SPRING_DATASOURCE_USERNAME",
+                        "SPRING_DATASOURCE_PASSWORD"
+                      ]
+                    }
+                  },
+                  "value": { "type": ["string", "number", "boolean"] },
+                  "valueFrom": { "type": "object" }
+                },
+                "additionalProperties": true
+              }
+            },
             "existingSecret": {
               "type": "object",
               "additionalProperties": false,
@@ -237,7 +263,16 @@
               "required": ["name", "urlKey", "usernameKey", "passwordKey"]
             }
           },
-          "required": ["enabled", "port", "name", "existingSecret"]
+          "required": [
+            "enabled",
+            "port",
+            "name",
+            "usernameFrom",
+            "passwordFrom",
+            "jdbcUrlFrom",
+            "extraEnv",
+            "existingSecret"
+          ]
         },
         "waitForReady": {
           "type": "object",
@@ -554,13 +589,109 @@
                     "properties": {
                       "external": {
                         "type": "object",
-                        "required": ["host", "name", "username", "password"],
+                        "required": ["host", "name"],
                         "properties": {
                           "host": { "type": "string", "minLength": 1 },
                           "name": { "type": "string", "minLength": 1 },
-                          "username": { "type": "string", "minLength": 1 },
-                          "password": { "type": "string", "minLength": 1 }
-                        }
+                          "username": { "type": "string" },
+                          "usernameFrom": { "type": "object" },
+                          "password": { "type": "string" },
+                          "passwordFrom": { "type": "object" }
+                        },
+                        "allOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "username": { "type": "string", "minLength": 1 }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "usernameFrom": { "type": "object", "minProperties": 1 }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "password": { "type": "string", "minLength": 1 }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "passwordFrom": { "type": "object", "minProperties": 1 }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "database": {
+                    "type": "object",
+                    "properties": {
+                      "external": {
+                        "type": "object",
+                        "properties": {
+                          "jdbcUrl": { "type": "string", "minLength": 1 },
+                          "jdbcUrlFrom": { "type": "object" },
+                          "username": { "type": "string" },
+                          "usernameFrom": { "type": "object" },
+                          "password": { "type": "string" },
+                          "passwordFrom": { "type": "object" }
+                        },
+                        "allOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "jdbcUrl": { "type": "string", "minLength": 1 }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "jdbcUrlFrom": { "type": "object", "minProperties": 1 }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "username": { "type": "string", "minLength": 1 }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "usernameFrom": { "type": "object", "minProperties": 1 }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "password": { "type": "string", "minLength": 1 }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "passwordFrom": { "type": "object", "minProperties": 1 }
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   }

--- a/charts/tolgee/values.yaml
+++ b/charts/tolgee/values.yaml
@@ -256,11 +256,23 @@ database:
     # -- External PostgreSQL username.
     username: ""
 
+    # -- Kubernetes valueFrom source for SPRING_DATASOURCE_USERNAME.
+    usernameFrom: {}
+
     # -- External PostgreSQL password.
     password: ""
 
+    # -- Kubernetes valueFrom source for SPRING_DATASOURCE_PASSWORD.
+    passwordFrom: {}
+
     # -- Full external JDBC URL override.
     jdbcUrl: ""
+
+    # -- Kubernetes valueFrom source for SPRING_DATASOURCE_URL.
+    jdbcUrlFrom: {}
+
+    # -- Extra env vars rendered before SPRING_DATASOURCE_* for external DB URL expansion.
+    extraEnv: []
 
     existingSecret:
       # -- Existing secret containing SPRING_DATASOURCE_* values.


### PR DESCRIPTION
## Summary

- add `database.external.usernameFrom`, `passwordFrom`, and `jdbcUrlFrom` for per-field Kubernetes `valueFrom` sources
- add `database.external.extraEnv` for helper vars rendered before datasource vars so Kubernetes can expand `jdbcUrl`
- keep `SPRING_DATASOURCE_*` names owned by the chart and reject them inside `database.external.extraEnv`
- bump Tolgee chart to `0.18.0`, update schema/docs, and add valid/invalid fixtures

## Context

This is an alternate implementation for [issue #140](https://github.com/icoretech/helm/issues/140), inspired by [PR #141](https://github.com/icoretech/helm/pull/141) from @criskurtin

The external PR solves the right problem, but this keeps datasource env ownership in the chart instead of requiring users to define the Spring env vars manually through `tolgee.extraEnv`

Resolves [issue #140](https://github.com/icoretech/helm/issues/140)

## Verification

- `helm dependency update charts/tolgee`
- `helm lint charts/tolgee`
- `helm unittest charts/tolgee`
- `bash charts/tolgee/scripts/test-schema.sh`
- `helm template t charts/tolgee -f charts/tolgee/values.yaml`
- `helm template t charts/tolgee -f charts/tolgee/ci/install-values.yaml`
- `helm template valuefrom charts/tolgee -f charts/tolgee/tests/values/valid-external-valuefrom.yaml`
- `kubeconform -strict -ignore-missing-schemas /tmp/tolgee-values.yaml.rendered`
- `kubeconform -strict -ignore-missing-schemas /tmp/tolgee-install-values.yaml.rendered`
- `helm template valuefrom charts/tolgee -f charts/tolgee/tests/values/valid-external-valuefrom.yaml | kubeconform -strict -ignore-missing-schemas`
- `ct lint --target-branch main`