### PR TITLE
feat(pgbouncer): expose service.trafficDistribution

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pgbouncer
 description: A Helm chart for deploying PgBouncer, a PostgreSQL connection pooler, on Kubernetes
 type: application
-version: 4.1.8
+version: 4.1.9
 appVersion: 1.25.2
 kubeVersion: ">= 1.31.0-0"
 icon: https://icoretech.github.io/helm/charts/pgbouncer/logo.png

--- a/charts/pgbouncer/README.md
+++ b/charts/pgbouncer/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the PgBouncer chart and
 | service.port | int | `5432` | The service port for PgBouncer. |
 | service.sessionAffinity | string | `"None"` | If "ClientIP", consecutive client requests will be directed to the same Pod |
 | service.sessionAffinityConfig | object | `{}` | sessionAffinityConfig Additional settings for the sessionAffinity sessionAffinityConfig:   clientIP:     timeoutSeconds: 180 |
+| service.trafficDistribution | string | `nil` | Traffic distribution preference for the Service, e.g. "PreferClose" for topology-aware routing. Requires Kubernetes >= 1.31. Omitted when unset. |
 | service.type | string | `"ClusterIP"` | Service type (e.g. ClusterIP, NodePort, LoadBalancer). |
 | serviceAccount.annotations | object | `{}` | Annotations for the created ServiceAccount. |
 | serviceAccount.name | string | `""` | Creates a new ServiceAccount if this is empty. |

--- a/charts/pgbouncer/templates/service.yaml
+++ b/charts/pgbouncer/templates/service.yaml
@@ -30,3 +30,6 @@ spec:
   {{- if .Values.service.sessionAffinityConfig }}
   sessionAffinityConfig: {{ toYaml .Values.service.sessionAffinityConfig | nindent 4 }}
   {{- end }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -70,6 +70,8 @@ service:
   #   clientIP:
   #     timeoutSeconds: 180
   sessionAffinityConfig: {}
+  # -- Traffic distribution preference for the Service, e.g. "PreferClose" for topology-aware routing. Requires Kubernetes >= 1.31. Omitted when unset.
+  trafficDistribution:
 
 # -- Additional labels to add to each PgBouncer pod.
 podLabels: {}


### PR DESCRIPTION
Closes #328

### What

Adds an optional `service.trafficDistribution` value to the **pgbouncer** chart, passed through to `Service.spec.trafficDistribution`.

### Why

`Service.spec.trafficDistribution` is GA in Kubernetes 1.31, and setting `PreferClose` keeps traffic in-zone when possible — reducing cross-AZ data-transfer cost and latency for a hot-path connection pooler like PgBouncer. The chart already requires `kubeVersion: '>= 1.31.0-0'`, but `templates/service.yaml` didn't expose the field, forcing downstream users to post-patch the rendered Service.

### Change

`templates/service.yaml` — rendered only when set, consistent with the existing `externalTrafficPolicy`/`sessionAffinity` passthroughs:

```yaml
{{- with .Values.service.trafficDistribution }}
trafficDistribution: {{ . }}
{{- end }}
```

- `values.yaml` — new `service.trafficDistribution` (defaults unset), with helm-docs comment.
- `README.md` — regenerated values row.
- `Chart.yaml` — version bump `4.1.8` → `4.1.9`.

Backward compatible: when unset, the Service is unchanged.

### Testing

- `helm template … --set service.trafficDistribution=PreferClose` → Service renders `trafficDistribution: PreferClose`.
- Unset → field omitted.
- `helm lint` passes.